### PR TITLE
refactor: allow model call to take list as prompt

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -3,7 +3,7 @@ import libem
 
 def positive():
     e1 = "Dyson Hot+Cool AM09 Jet Focus heater and fan, White/Silver"
-    e2 = "Dyson AM09 Hot + Cool Jet Focus Fan Heater - Black japan"
+    e2 = "Dyson AM09 Hot + Cool Jet Focus Fan Heater - W/S - japan"
 
     is_match = libem.chat(f"Match two entities entity 1: {e1}; entity 2: {e2}")
 

--- a/libem/core/model.py
+++ b/libem/core/model.py
@@ -120,6 +120,7 @@ def openai(prompt: str | list,
                 })
                 if verbose:
                     libem.info(f"Tool: {function_name} - {function_response}")
+            tool_calls = []
 
             if num_model_calls < max_model_call:
                 # Call the model again with the tool outcomes

--- a/libem/core/model.py
+++ b/libem/core/model.py
@@ -26,7 +26,7 @@ def openai(prompt: str | list,
            temperature: float = 0.0,
            seed: int = None,
            max_model_call: int = 3,
-           return_tool_output: bool = False,
+           return_tool_outputs: bool = False,
            verbose: bool = True,
            ) -> str or (str, dict):
     if not os.environ.get("OPENAI_API_KEY"):
@@ -159,7 +159,7 @@ def openai(prompt: str | list,
         }
     })
 
-    if return_tool_output:
+    if return_tool_outputs:
         return response_message.content, tool_outputs
     else:
         return response_message.content

--- a/libem/core/model.py
+++ b/libem/core/model.py
@@ -30,6 +30,7 @@ def openai(prompt: str | list,
            ) -> str:
     if not os.environ.get("OPENAI_API_KEY"):
         raise EnvironmentError(f"OPENAI_API_KEY is not set.")
+
     client = OpenAI()
 
     num_model_calls = 0
@@ -100,8 +101,6 @@ def openai(prompt: str | list,
                 function_name = tool_call.function.name
                 function_to_call = available_functions[function_name]
                 function_args = json.loads(tool_call.function.arguments)
-
-                libem.info(f"Tool: {function_name} - running ..")
                 function_response = function_to_call(**function_args)
                 messages.append(
                     {

--- a/libem/core/model.py
+++ b/libem/core/model.py
@@ -26,6 +26,7 @@ def openai(prompt: str | list,
            temperature: float = 0.0,
            seed: int = None,
            max_model_call: int = 3,
+           verbose: bool = True,
            ) -> str:
     if not os.environ.get("OPENAI_API_KEY"):
         raise EnvironmentError(f"OPENAI_API_KEY is not set.")
@@ -94,7 +95,7 @@ def openai(prompt: str | list,
         # Call the tools
         while tool_calls:
             messages.append(response_message)
-            
+
             for tool_call in tool_calls:
                 function_name = tool_call.function.name
                 function_to_call = available_functions[function_name]
@@ -118,7 +119,8 @@ def openai(prompt: str | list,
                         "response": function_response
                     }
                 })
-                libem.info(f"Tool: {function_name} - {function_response}")
+                if verbose:
+                    libem.info(f"Tool: {function_name} - {function_response}")
 
             if num_model_calls < max_model_call:
                 # Call the model again with the tool outcomes


### PR DESCRIPTION
Changed logic of when to invoke multiple model calls, allow list as input, and return tool outputs.