### PR TITLE
fix: reset args.kwargs before running benchmark suites

### DIFF
--- a/benchmark/suite/gpt-35-turbo.py
+++ b/benchmark/suite/gpt-35-turbo.py
@@ -24,7 +24,8 @@ def run_benchmark():
     reports = {}
     for dataset in datasets:
         args.name = dataset
-
+        args.kwargs = {}
+        
         print(f"Running {dataset}...")
         print(args)
 

--- a/benchmark/suite/gpt-4-turbo.py
+++ b/benchmark/suite/gpt-4-turbo.py
@@ -24,7 +24,8 @@ def run_benchmark():
     reports = {}
     for dataset in datasets:
         args.name = dataset
-
+        args.kwargs = {}
+        
         print(f"Running {dataset}...")
         print(args)
 

--- a/benchmark/suite/gpt-4.py
+++ b/benchmark/suite/gpt-4.py
@@ -24,7 +24,8 @@ def run_benchmark():
     reports = {}
     for dataset in datasets:
         args.name = dataset
-
+        args.kwargs = {}
+        
         print(f"Running {dataset}...")
         print(args)
 

--- a/benchmark/suite/gpt-4o-mini.py
+++ b/benchmark/suite/gpt-4o-mini.py
@@ -24,7 +24,8 @@ def run_benchmark():
     reports = {}
     for dataset in datasets:
         args.name = dataset
-
+        args.kwargs = {}
+        
         print(f"Running {dataset}...")
         print(args)
 

--- a/benchmark/suite/gpt-4o.py
+++ b/benchmark/suite/gpt-4o.py
@@ -24,7 +24,8 @@ def run_benchmark():
     reports = {}
     for dataset in datasets:
         args.name = dataset
-
+        args.kwargs = {}
+        
         print(f"Running {dataset}...")
         print(args)
 

--- a/benchmark/suite/llama3.py
+++ b/benchmark/suite/llama3.py
@@ -24,7 +24,8 @@ def run_benchmark():
     reports = {}
     for dataset in datasets:
         args.name = dataset
-
+        args.kwargs = {}
+        
         print(f"Running {dataset}...")
         print(args)
 


### PR DESCRIPTION
This pr fixed keyError issue when running different datasets in all files from benchmark/suite.

Relavent issue: #67  bullet point 1

issue: args.kwargs kept values from old dataset.

fIx: reset args.kwargs before running dataset