### PR TITLE
feat: add option to partition by keys when blocking

### DIFF
--- a/libem/block/function.py
+++ b/libem/block/function.py
@@ -1,5 +1,8 @@
+import heapq
+import itertools
 from tqdm import tqdm
 from fuzzywuzzy import fuzz
+from operator import itemgetter
 from collections.abc import Iterable
 
 from libem.block import parameter
@@ -27,39 +30,92 @@ schema = {
 }
 
 
-def func(left, right=None):
+def func(left: Iterable[str | dict], 
+         right: Iterable[str | dict] | None = None, 
+         on: str | list | None = None) -> Iterable[dict]:
     if right is None:
-        return block(left)
+        return block(left, on)
     else:
-        return block_left_right(left, right)
+        return block_left_right(left, right, on)
 
 
-def block(records: Iterable[str | dict]) -> Iterable[dict]:
+def block(records: Iterable[str | dict], 
+          on: str | list | None = None) -> Iterable[dict]:
+    if on:
+        # group by
+        if isinstance(on, str):
+            records = sorted(records, key=itemgetter(on))
+            records = itertools.groupby(records, key=itemgetter(on))
+        elif isinstance(on, list):
+            records = sorted(records, key=itemgetter(*on))
+            records = itertools.groupby(records, key=itemgetter(*on))
+        
+        for _, group in tqdm(records, desc='Blocking'):
+            # duplicate the iterable to allow for nested iteration
+            left, right = itertools.tee(group, 2)
+            yield from block_similarity(left, right, block_same_index=False)
+    else:
+        # duplicate the iterable to allow for nested iteration
+        left, right = itertools.tee(records, 2)
+        yield from block_similarity(left, right, 
+                                    block_same_index=False, 
+                                    progress_bar=True)
+
+
+def block_left_right(left: Iterable[str | dict], 
+                     right: Iterable[str | dict],
+                     on: str | list | None = None) -> Iterable[dict]:
+    if on:
+        # group by
+        if isinstance(on, str):
+            left = sorted(left, key=itemgetter(on))
+            left = itertools.groupby(left, key=itemgetter(on))
+            right = sorted(right, key=itemgetter(on))
+            right = itertools.groupby(right, key=itemgetter(on))
+        elif isinstance(on, list):
+            left = sorted(left, key=itemgetter(*on))
+            left = itertools.groupby(left, key=itemgetter(*on))
+            right = sorted(right, key=itemgetter(*on))
+            right = itertools.groupby(right, key=itemgetter(*on))
+        
+        # inner join the two iterables
+        records = heapq.merge(left, right, key=lambda x: x[0])
+        last_key, last_val = None, []
+        for key, val in tqdm(records, desc='Blocking'):
+            if key == last_key:
+                last_key = None
+                yield from block_similarity(last_val, val)
+            else:
+                last_key = key
+                last_val = list(val)
+    else:
+        yield from block_similarity(left, right, progress_bar=True)
+
+
+def block_similarity(left: Iterable[str | dict], 
+                     right: Iterable[str | dict],
+                     block_same_index: bool = True,
+                     progress_bar: bool = False) -> Iterable[dict]:
+    ''' Block using string similarity. '''
+    
+    # set similarity and convert right iterable to list
     similarity = parameter.similarity()
+    right = list(right)
+    
+    if progress_bar:
+        left = tqdm(left, desc='Blocking')
 
-    for i, l in enumerate(
-            tqdm(records, desc='Blocking')):
+    for i, l in enumerate(left):
         left_str = convert_to_str(l)
 
         for j, r in enumerate(
-                tqdm(records, desc='Comparing', mininterval=0.01, leave=False)):
-            if i >= j:
+                tqdm(right, desc='Comparing', mininterval=0.01, leave=False)):
+            if not block_same_index and i >= j:
                 continue
+            
             right_str = convert_to_str(r)
             if fuzz.token_set_ratio(left_str, right_str) >= similarity:
                 yield {'left': l, 'right': r}
-
-
-def block_left_right(left: Iterable[str | dict], right: Iterable[str | dict]) -> Iterable[dict]:
-    similarity = parameter.similarity()
-
-    for l in tqdm(left, desc='Blocking'):
-        left_str = convert_to_str(l)
-        for r in tqdm(right, desc='Comparing', mininterval=0.01, leave=False):
-            right_str = convert_to_str(r)
-            if fuzz.token_set_ratio(left_str, right_str) >= similarity:
-                yield {'left': l, 'right': r}
-
 
 def convert_to_str(record: str | dict):
     match record:

--- a/libem/block/function.py
+++ b/libem/block/function.py
@@ -30,72 +30,73 @@ schema = {
 }
 
 
-def func(left: Iterable[str | dict], 
-         right: Iterable[str | dict] | None = None, 
-         on: str | list | None = None) -> Iterable[dict]:
+def func(left, right=None, key=None):
     if right is None:
-        return block(left, on)
+        return block(left, key)
     else:
-        return block_left_right(left, right, on)
+        return block_left_right(left, right, key)
 
 
 def block(records: Iterable[str | dict], 
-          on: str | list | None = None) -> Iterable[dict]:
-    if on:
+          key: str | list | None = None) -> Iterable[dict]:
+    if key:
+        if isinstance(key, str):
+            key = [key]
+        elif not isinstance(key, list):
+            raise ValueError("Key must be a string or a list of strings.")
+        
         # group by
-        if isinstance(on, str):
-            records = sorted(records, key=itemgetter(on))
-            records = itertools.groupby(records, key=itemgetter(on))
-        elif isinstance(on, list):
-            records = sorted(records, key=itemgetter(*on))
-            records = itertools.groupby(records, key=itemgetter(*on))
+        records = sorted(records, key=itemgetter(*key))
+        records = itertools.groupby(records, key=itemgetter(*key))
         
         for _, group in tqdm(records, desc='Blocking'):
             # duplicate the iterable to allow for nested iteration
             left, right = itertools.tee(group, 2)
-            yield from block_similarity(left, right, block_same_index=False)
+            yield from compare(left, right, 
+                               remove_keys=key,
+                               compare_same_index=False)
     else:
         # duplicate the iterable to allow for nested iteration
         left, right = itertools.tee(records, 2)
-        yield from block_similarity(left, right, 
-                                    block_same_index=False, 
-                                    progress_bar=True)
+        yield from compare(left, right, 
+                           compare_same_index=False, 
+                           progress_bar=True)
 
 
 def block_left_right(left: Iterable[str | dict], 
                      right: Iterable[str | dict],
-                     on: str | list | None = None) -> Iterable[dict]:
-    if on:
-        # group by
-        if isinstance(on, str):
-            left = sorted(left, key=itemgetter(on))
-            left = itertools.groupby(left, key=itemgetter(on))
-            right = sorted(right, key=itemgetter(on))
-            right = itertools.groupby(right, key=itemgetter(on))
-        elif isinstance(on, list):
-            left = sorted(left, key=itemgetter(*on))
-            left = itertools.groupby(left, key=itemgetter(*on))
-            right = sorted(right, key=itemgetter(*on))
-            right = itertools.groupby(right, key=itemgetter(*on))
+                     key: str | list | None = None) -> Iterable[dict]:
+    if key:
+        if isinstance(key, str):
+            key = [key]
+        elif not isinstance(key, list):
+            raise ValueError("Key must be a string or a list of strings.")
+        
+        # group by key
+        left = sorted(left, key=itemgetter(*key))
+        left = itertools.groupby(left, key=itemgetter(*key))
+        right = sorted(right, key=itemgetter(*key))
+        right = itertools.groupby(right, key=itemgetter(*key))
         
         # inner join the two iterables
-        records = heapq.merge(left, right, key=lambda x: x[0])
-        last_key, last_val = None, []
-        for key, val in tqdm(records, desc='Blocking'):
-            if key == last_key:
-                last_key = None
-                yield from block_similarity(last_val, val)
+        records = heapq.merge(right, left, key=lambda x: x[0])
+        last_k, last_v = None, []
+        for k, v in tqdm(records, desc='Blocking'):
+            if k == last_k:
+                last_k = None
+                yield from compare(v, last_v, remove_keys=key)
             else:
-                last_key = key
-                last_val = list(val)
+                last_k = k
+                last_v = list(v)
     else:
-        yield from block_similarity(left, right, progress_bar=True)
+        yield from compare(left, right, progress_bar=True)
 
 
-def block_similarity(left: Iterable[str | dict], 
-                     right: Iterable[str | dict],
-                     block_same_index: bool = True,
-                     progress_bar: bool = False) -> Iterable[dict]:
+def compare(left: Iterable[str | dict], 
+            right: Iterable[str | dict],
+            remove_keys: list | None = None,
+            compare_same_index: bool = True,
+            progress_bar: bool = False) -> Iterable[dict]:
     ''' Block using string similarity. '''
     
     # set similarity and convert right iterable to list
@@ -106,22 +107,28 @@ def block_similarity(left: Iterable[str | dict],
         left = tqdm(left, desc='Blocking')
 
     for i, l in enumerate(left):
-        left_str = convert_to_str(l)
+        left_str = convert_to_str(l, remove_keys)
 
         for j, r in enumerate(
                 tqdm(right, desc='Comparing', mininterval=0.01, leave=False)):
-            if not block_same_index and i >= j:
+            if not compare_same_index and i >= j:
                 continue
             
-            right_str = convert_to_str(r)
+            right_str = convert_to_str(r, remove_keys)
             if fuzz.token_set_ratio(left_str, right_str) >= similarity:
                 yield {'left': l, 'right': r}
 
-def convert_to_str(record: str | dict):
+
+def convert_to_str(record: str | dict, remove_keys: Iterable | None = None):
     match record:
         case str():
             return record
         case dict():
+            if remove_keys:
+                record = record.copy()
+                for key in remove_keys:
+                    del record[key]
+            
             return ' '.join(map(str, record.values()))
         case _:
             return str(record)

--- a/libem/block/interface.py
+++ b/libem/block/interface.py
@@ -17,5 +17,6 @@ class Pair(TypedDict):
 Output = Iterable[Pair]
 
 
-def block(left: Left, right: Right = None) -> Output:
-    yield from func(left, right)
+def block(left: Left, right: Right = None, 
+          on: str | list | None = None) -> Output:
+    yield from func(left, right, on)

--- a/test/block.py
+++ b/test/block.py
@@ -1,0 +1,69 @@
+import libem
+
+dataset_a = [{'i': 1, 'j': 'apple'}, {'i': 2, 'j': 'apple'}, {'i': 10, 'j': 'apple'}, 
+             {'i': 1, 'j': 'apple'}, {'i': 8, 'j': 'apple'}, {'i': 5, 'j': 'orange'}, 
+             {'i': 5, 'j': 'orange'}, {'i': 8, 'j': 'orange'}, {'i': 0, 'j': 'orange'}, 
+             {'i': 1, 'j': 'orange'}, ]
+
+dataset_b = [{'i': 1, 'j': 'aple'}, {'i': 2, 'j': 'apple'}, {'i': 7, 'j': 'apple'}, 
+             {'i': 3, 'j': 'apple'}, {'i': 4, 'j': 'apple'}, {'i': 0, 'j': 'orange'}, 
+             {'i': 7, 'j': 'orange'}, {'i': 0, 'j': 'orange'}, {'i': 5, 'j': 'orange'}, 
+             {'i': 6, 'j': 'orange'}, ]
+
+libem.calibrate({
+    "libem.block.parameter.similarity": 0
+})
+
+out = list(libem.block(iter(dataset_a), on='i'))
+assert out == [{'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'apple'}}, 
+               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
+               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+               {'left': {'i': 8, 'j': 'apple'}, 'right': {'i': 8, 'j': 'orange'}},]
+out = list(libem.block(iter(dataset_a), iter(dataset_b), on='i'))
+assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+               {'left': {'i': 1, 'j': 'orange'}, 'right': {'i': 1, 'j': 'aple'}}, 
+               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+
+out = list(libem.block(iter(dataset_a), iter(dataset_b), on=['i', 'j']))
+assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+
+libem.calibrate({
+    "libem.block.parameter.similarity": 70
+})
+
+out = list(libem.block(dataset_a, dataset_b, on='i'))
+assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+
+libem.calibrate({
+    "libem.block.parameter.similarity": 100
+})
+
+out = list(libem.block(dataset_a, dataset_b, on='i'))
+assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},  
+               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+
+out = list(libem.block(dataset_a, dataset_b))
+assert out == [{'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},]

--- a/test/block.py
+++ b/test/block.py
@@ -38,7 +38,7 @@ assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
 
 libem.calibrate({
-    "libem.block.parameter.similarity": 70
+    "libem.block.parameter.similarity": 50
 })
 
 out = list(libem.block(dataset_a, dataset_b, on='i'))


### PR DESCRIPTION
#### What this PR does / why we need it:
- Add option to partition by keys when blocking
- Add support for passing in iterators
- Add unit test for block

#### Which issue(s) this PR addresses (if any):
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Addresses #<issue number>`, or `Addresses (paste link of issue)`.
-->
Addresses #79 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- Add option to partition by keys when blocking
```
