### PR TITLE
feat: add plotting to benchmark suites

### DIFF
--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -116,6 +116,9 @@ def args() -> argparse.Namespace:
     parser.add_argument("--num-shots", dest='num_shots', nargs='?',
                         help="The number of shots to use for in-context learning.",
                         type=int, default=0)
+    parser.add_argument("--plot", dest='plot',
+                        help="Plot the results of the last benchmark suite run.",
+                        action='store_true', default=False)
 
     # libem configurations
     parser.add_argument("-m", "--model", dest='model', nargs='?',

--- a/benchmark/suite/batch.py
+++ b/benchmark/suite/batch.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+import benchmark as bm
 from benchmark.suite.util import (
     run_benchmark, report_to_dataframe, 
     tabulate, plot, save, show
@@ -10,6 +11,17 @@ name = os.path.basename(__file__).replace(".py", "")
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:31] == name:
+                print(f"Plotting run: {file.name}")
+                plot(file, x_axis="batch_size")
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     args.block = False
     args.match = True
     args.num_pairs = -1
@@ -33,7 +45,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
     
     df = report_to_dataframe(reports, key_col="batch_size")
-    save(df, f"{name}-{args.name}")
+    file_name = save(df, f"{name}-{args.name}")
 
     # generate markdown table
     df = df[["batch_size", "f1", "latency", "per_pair_latency",
@@ -49,7 +61,7 @@ def run(args):
     df = df.rename(columns=field_names)
 
     tabulate(df, f"{name}-{args.name}")
-    plot(df)
+    plot(file_name, x_axis="batch_size")
     show(df)
 
     return reports

--- a/benchmark/suite/block.py
+++ b/benchmark/suite/block.py
@@ -12,6 +12,17 @@ name = os.path.basename(__file__).replace(".py", "")
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:-4] == name:
+                print(f"Plotting run: {file.name}")
+                plot(file)
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     benchmarks = bm.classic_benchmarks.keys()
 
     args.block = True
@@ -39,7 +50,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
     
     df = report_to_dataframe(reports)
-    save(df, name)
+    file_name = save(df, name)
     
     # generate markdown table
     df = df[["benchmark", "similarity_cutoff", "percent_blocked", "f1", "throughput"]]
@@ -54,7 +65,7 @@ def run(args):
     df = df.rename(columns=field_names)
     
     tabulate(df, name)
-    plot(df)
+    plot(file_name)
     show(df)
 
     return reports

--- a/benchmark/suite/gpt_35_turbo.py
+++ b/benchmark/suite/gpt_35_turbo.py
@@ -8,10 +8,21 @@ from benchmark.suite.util import (
     tabulate, plot, save, show
 )
 
-name = os.path.basename(__file__).replace(".py", "")
+name = os.path.basename(__file__).replace(".py", "").replace('_', '-').replace('35', '3.5')
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:-4].replace('35', '3.5') == name:
+                print(f"Plotting run: {file.name}")
+                plot(file)
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     benchmarks = bm.classic_benchmarks.keys()
 
     args.block = False
@@ -35,7 +46,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
 
     df = report_to_dataframe(reports)
-    save(df, name)
+    file_name = save(df, name)
 
     # generate markdown table
     df["pairs_per_$"] = df["num_pairs"] // df["cost"]
@@ -60,7 +71,7 @@ def run(args):
     df = df.rename(columns=field_names)
     
     tabulate(df, name)
-    plot(df)
+    plot(file_name)
     show(df)
 
     return reports

--- a/benchmark/suite/gpt_4.py
+++ b/benchmark/suite/gpt_4.py
@@ -8,10 +8,21 @@ from benchmark.suite.util import (
     tabulate, plot, save, show
 )
 
-name = os.path.basename(__file__).replace(".py", "")
+name = os.path.basename(__file__).replace(".py", "").replace('_', '-')
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:-4] == name:
+                print(f"Plotting run: {file.name}")
+                plot(file)
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     benchmarks = bm.classic_benchmarks.keys()
 
     args.block = False
@@ -35,7 +46,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
 
     df = report_to_dataframe(reports)
-    save(df, name)
+    file_name = save(df, name)
 
     # generate markdown table
     df["pairs_per_$"] = df["num_pairs"] // df["cost"]
@@ -60,7 +71,7 @@ def run(args):
     df = df.rename(columns=field_names)
     
     tabulate(df, name)
-    plot(df)
+    plot(file_name)
     show(df)
 
     return reports

--- a/benchmark/suite/gpt_4_turbo.py
+++ b/benchmark/suite/gpt_4_turbo.py
@@ -8,10 +8,21 @@ from benchmark.suite.util import (
     tabulate, plot, save, show
 )
 
-name = os.path.basename(__file__).replace(".py", "")
+name = os.path.basename(__file__).replace(".py", "").replace('_', '-')
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:-4] == name:
+                print(f"Plotting run: {file.name}")
+                plot(file)
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     benchmarks = bm.classic_benchmarks.keys()
 
     args.block = False
@@ -35,7 +46,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
 
     df = report_to_dataframe(reports)
-    save(df, name)
+    file_name = save(df, name)
 
     # generate markdown table
     df["pairs_per_$"] = df["num_pairs"] // df["cost"]
@@ -60,7 +71,7 @@ def run(args):
     df = df.rename(columns=field_names)
     
     tabulate(df, name)
-    plot(df)
+    plot(file_name)
     show(df)
 
     return reports

--- a/benchmark/suite/gpt_4o.py
+++ b/benchmark/suite/gpt_4o.py
@@ -8,10 +8,21 @@ from benchmark.suite.util import (
     tabulate, plot, save, show
 )
 
-name = os.path.basename(__file__).replace(".py", "")
+name = os.path.basename(__file__).replace(".py", "").replace('_', '-')
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:-4] == name:
+                print(f"Plotting run: {file.name}")
+                plot(file)
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     benchmarks = bm.classic_benchmarks.keys()
 
     args.block = False
@@ -35,7 +46,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
 
     df = report_to_dataframe(reports)
-    save(df, name)
+    file_name = save(df, name)
 
     # generate markdown table
     df["pairs_per_$"] = df["num_pairs"] // df["cost"]
@@ -60,7 +71,7 @@ def run(args):
     df = df.rename(columns=field_names)
     
     tabulate(df, name)
-    plot(df)
+    plot(file_name)
     show(df)
 
     return reports

--- a/benchmark/suite/gpt_4o_mini.py
+++ b/benchmark/suite/gpt_4o_mini.py
@@ -8,10 +8,21 @@ from benchmark.suite.util import (
     tabulate, plot, save, show
 )
 
-name = os.path.basename(__file__).replace(".py", "")
+name = os.path.basename(__file__).replace(".py", "").replace('_', '-')
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:-4] == name:
+                print(f"Plotting run: {file.name}")
+                plot(file)
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     benchmarks = bm.classic_benchmarks.keys()
 
     args.block = False
@@ -35,7 +46,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
 
     df = report_to_dataframe(reports)
-    save(df, name)
+    file_name = save(df, name)
 
     # generate markdown table
     df["pairs_per_$"] = df["num_pairs"] // df["cost"]
@@ -60,7 +71,7 @@ def run(args):
     df = df.rename(columns=field_names)
     
     tabulate(df, name)
-    plot(df)
+    plot(file_name)
     show(df)
 
     return reports

--- a/benchmark/suite/llama3.py
+++ b/benchmark/suite/llama3.py
@@ -12,6 +12,17 @@ name = os.path.basename(__file__).replace(".py", "")
 
 
 def run(args):
+    if args.plot:
+        files = list(os.scandir(bm.result_dir))
+        for file in reversed(files):
+            if file.name[26:-4] == name:
+                print(f"Plotting run: {file.name}")
+                plot(file)
+                return
+        
+        print(f"Could not find past {name} suite results to plot.")
+        return
+    
     benchmarks = bm.classic_benchmarks.keys()
 
     args.block = False
@@ -35,7 +46,7 @@ def run(args):
     print(f"Benchmark: Suite done in: {time.time() - start:.2f}s.")
 
     df = report_to_dataframe(reports)
-    save(df, name)
+    file_name = save(df, name)
 
     # generate markdown table
     df = df[["benchmark", "precision", "recall", "f1", "throughput"]]
@@ -55,7 +66,7 @@ def run(args):
     df = df.rename(columns=field_names)
     
     tabulate(df, name)
-    plot(df)
+    plot(file_name)
     show(df)
 
     return reports

--- a/benchmark/suite/util.py
+++ b/benchmark/suite/util.py
@@ -32,7 +32,6 @@ def report_to_dataframe(reports, key_col: str = "benchmark"):
 
 
 def tabulate(df: pd.DataFrame, name: str):
-    name = name.replace('_', '-')
     output_file = os.path.join(
                     bm.table_dir,
                     f"{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}-"
@@ -43,12 +42,28 @@ def tabulate(df: pd.DataFrame, name: str):
     print(f"Markdown table saved to: {output_file}")
 
 
-def plot(df: pd.DataFrame):
-    pass
+def plot(file: str, x_axis: str = 'benchmark'):
+    import seaborn as sns
+    from matplotlib import pyplot as plt
+    
+    df = pd.read_csv(file)
+    sns.set_theme(font_scale=1.3)
+    sns.barplot(df, x=x_axis, y='f1', color='#2ecc71', width=0.7)
+    plt.xticks(rotation=90)
+    plt.ylim(0, 100)
+    plt.title('')
+    plt.xlabel('')
+    plt.ylabel("F1 Score (%)")
+    
+    output_file = os.path.join(
+                    bm.figure_dir,
+                    f"{os.path.basename(file)[:-4]}.svg")
+    plt.savefig(output_file, format='svg', bbox_inches = "tight")
+    
+    print(f"Plot saved to: {output_file}")
 
 
 def save(df: pd.DataFrame, name: str):
-    name = name.replace('_', '-')
     output_file = os.path.join(
                     bm.result_dir,
                     f"{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}-"
@@ -57,6 +72,8 @@ def save(df: pd.DataFrame, name: str):
     df.to_csv(output_file, index=False)
     
     print(f"Results saved to: {output_file}")
+    
+    return output_file
 
 
 def show(df: pd.DataFrame):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tqdm
 recordlinkage
 duckdb
 pymongo
+seaborn


### PR DESCRIPTION
#### What this PR does / why we need it:
- Add plotting to benchmark suites; use `--plot` flag to plot from the last benchmark suite run results.

#### Which issue(s) this PR addresses (if any):
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Addresses #<issue number>`, or `Addresses (paste link of issue)`.
-->
Addresses #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- Add --plot flag to the benchmark module to plot the last benchmark suite run
- New benchmark suite runs will automatically save plots to 
```
