### PR TITLE
fix: add option to change LIBEM_SAMPLE_DATA_PATH in config.yaml

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -35,6 +35,11 @@ The `classic` directory includes the following available benchmarks, each using 
 
 The `suite` directory contains benchmark suites that deep-dive into aspects of Libem performance.
 
+Note: if `libem` is installed via pip, specify the location of `libem-sample-data` via cli:
+```
+libem configure
+```
+
 ## Blocking
 
 To run a single blocking benchmark in `/classic`:

--- a/cli/libem
+++ b/cli/libem
@@ -7,6 +7,7 @@ import argparse
 import pprint
 
 import libem
+import libem.prepare.datasets as datasets
 from libem.match.parameter import tools
 from libem.core.struct import Index
 
@@ -97,6 +98,15 @@ def configure(args):
     # If no input, keep the existing key; otherwise, update
     if new_claude_key:
         config['CLAUDE_API_KEY'] = new_claude_key
+    
+    # Prompt for LIBEM_SAMPLE_DATA_PATH
+    existing_sample_data_path = datasets.LIBEM_SAMPLE_DATA_PATH
+    sample_data_path = input(f"Enter the path to libem-sample-data (press Enter to "
+                             f"keep existing location: {existing_sample_data_path}): ").strip()
+    
+    # If no input, keep existing path; otherwise, update
+    if sample_data_path:
+        config['LIBEM_SAMPLE_DATA_PATH'] = sample_data_path
 
     ...
 

--- a/libem/prepare/datasets/__init__.py
+++ b/libem/prepare/datasets/__init__.py
@@ -3,10 +3,16 @@ import json
 import random
 from typing import Iterable
 
-LIBEM_SAMPLE_DATA_PATH = os.path.join(
-    os.path.dirname(__file__),
-    '..', '..', '..', '..',
-    'libem-sample-data')
+import libem
+
+LIBEM_SAMPLE_DATA_PATH = libem.LIBEM_CONFIG.get(
+    "LIBEM_SAMPLE_DATA_PATH", 
+    os.path.join(
+        os.path.dirname(__file__),
+        '..', '..', '..', '..',
+        'libem-sample-data'
+    )
+)
 
 
 def load(dataset: Iterable[dict], num_samples=-1, stringify=True) \


### PR DESCRIPTION
#### What this PR does / why we need it:
When the libem module is installed through pip, `LIBEM_SAMPLE_DATA_PATH` will not point to the correct/desired location, so the option to change the path is needed.

#### Which issue(s) this PR addresses (if any):
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Addresses #<issue number>`, or `Addresses (paste link of issue)`.
-->
Addresses #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
