### PR TITLE
feat: add ability to reset libem.calibrate calls

### DIFF
--- a/benchmark/suite/util.py
+++ b/benchmark/suite/util.py
@@ -8,8 +8,6 @@ import benchmark as bm
 
 
 def run_benchmark(benchmark: str, args):
-    libem.reset()
-    
     _args = copy.deepcopy(args)
     _args.name = benchmark
     benchmark = bm.benchmarks[benchmark]

--- a/examples/optimize/async_batch.py
+++ b/examples/optimize/async_batch.py
@@ -21,8 +21,6 @@ def main():
     libem.pprint(before)
     print()
 
-    libem.reset()
-
     print("Asynchronous execution with batch size 5:")
     libem.calibrate({
         "libem.match.parameter.sync": False,

--- a/examples/optimize/async_request.py
+++ b/examples/optimize/async_request.py
@@ -20,8 +20,6 @@ def main():
     libem.pprint(before)
     print()
 
-    libem.reset()
-
     print("Asynchronous execution:")
     libem.calibrate({
         "libem.match.parameter.sync": False,

--- a/examples/optimize/prompt_batch.py
+++ b/examples/optimize/prompt_batch.py
@@ -21,8 +21,6 @@ def main():
     libem.pprint(before)
     print()
 
-    libem.reset()
-
     print("With batch:")
     libem.calibrate({
         "libem.match.parameter.sync": True,

--- a/examples/tune/shots.py
+++ b/examples/tune/shots.py
@@ -25,7 +25,6 @@ def run():
         sort_dicts=False,
     )
 
-    libem.reset()
     print("After few-shot:")
 
     libem.calibrate({

--- a/libem/interface.py
+++ b/libem/interface.py
@@ -38,10 +38,10 @@ from libem.resolve.link.interface import link
 _ = match, block, extract, cluster, dedupe, link
 
 from libem.tune.calibrate.interface import (
-    calibrate, export
+    calibrate, reset, export
 )
 
-_ = calibrate, export
+_ = calibrate, reset, export
 
 """ Configurations """
 
@@ -51,10 +51,6 @@ def config():
         toolchain="libem",
         nest=True,
     )
-
-
-def reset():
-    model.reset()
 
 
 def debug_on():

--- a/libem/tune/calibrate/function.py
+++ b/libem/tune/calibrate/function.py
@@ -10,6 +10,7 @@ from libem.core.struct import (
 schema = {}
 
 
+# Cache the original/non-calibrated values to allow for resetting
 cache = {}
 
 def func(config, verbose=False):

--- a/libem/tune/calibrate/function.py
+++ b/libem/tune/calibrate/function.py
@@ -10,6 +10,8 @@ from libem.core.struct import (
 schema = {}
 
 
+cache = {}
+
 def func(config, verbose=False):
     for path, value in config.items():
         # Split the path into module and attribute parts
@@ -24,11 +26,20 @@ def func(config, verbose=False):
         except:
             raise Exception(f"unable to find parameter {path}")
         assert isinstance(parameter, Parameter), f"invalid parameter {path}"
+        
+        # Cache the original value
+        if path not in cache:
+            cache[path] = parameter()
 
         parameter.update(value)
 
     if verbose:
         libem.info(f"[calibrate] {config}")
+
+
+def reset(verbose=False):
+    func(cache, verbose=verbose)
+    cache.clear()
 
 
 def collect(tool: str, depth=sys.maxsize,

--- a/libem/tune/calibrate/interface.py
+++ b/libem/tune/calibrate/interface.py
@@ -1,11 +1,13 @@
 import pprint
 
 from libem.tune.calibrate import func
-from libem.tune.calibrate.function import collect, flatten, unflatten
+from libem.tune.calibrate.function import reset, collect, flatten, unflatten
 
 
 def calibrate(*args, **kwargs):
     return func(*args, **kwargs)
+
+_ = reset
 
 
 def export(toolchain="libem",


### PR DESCRIPTION
#### What this PR does / why we need it:
- add ability to reset libem.calibrate calls (necessary for libem serve functionality)

#### Which issue(s) this PR addresses (if any):
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Addresses #<issue number>`, or `Addresses (paste link of issue)`.
-->
Addresses #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- libem.reset() no longer resets external model clients, use libem.model.reset() instead
```
