### PR TITLE
multiprocessing support for blocking

### DIFF
--- a/benchmark/util.py
+++ b/benchmark/util.py
@@ -130,23 +130,13 @@ def run_block(test_set: Iterable, args: argparse.Namespace):
     max_pairs = len(left) * len(right)
 
     print(f"Benchmark: Blocking {max_pairs} potential pairs "
-          f"from the {args.name} benchmark", end='')
-    
-    if args.num_pairs > 0:
-        print(f",\nBenchmark: stopping after the first "
-              f"{'pair' if args.num_pairs == 1 else f'{args.num_pairs} pairs'} "
-              f"that pass{f'es' if args.num_pairs == 1 else ''} the cutoff:")
-    else:
-        print(":")
+          f"from the {args.name} benchmark:", end='')
 
     blocked = []
     start_time = time.time()
     for pair in libem.block(left, right):
         blocked.append(pair)
-
-        # check num_pairs stop condition
-        if 0 < args.num_pairs <= len(blocked):
-            break
+    
     total_time = time.time() - start_time
     
     # generate output and stats
@@ -168,25 +158,8 @@ def run_block(test_set: Iterable, args: argparse.Namespace):
                 'label': 0
             })
 
-    # if didn't run through the entire dataset,
-    # go through all pairs to find the fn and total pairs
-    if 0 < args.num_pairs <= len(blocked):
-        total_pairs, i = 0, 0
-        for l, r in product(left, right):
-            total_pairs += 1
-            
-            if l == blocked[i]['left'] and r == blocked[i]['right']:
-                i += 1
-                
-                # stop early if reached end of blocked
-                if i == len(blocked) - 1:
-                    break
-            else:
-                if {'left': l, 'right': r} in true:
-                    fn.append(pair)
-    else:
-        total_pairs = max_pairs
-        fn = [pair for pair in true if pair not in tp]
+    total_pairs = max_pairs
+    fn = [pair for pair in true if pair not in tp]
     
     num_tn = total_pairs - len(tp) - len(fp) - len(fn)
     

--- a/libem/block/function.py
+++ b/libem/block/function.py
@@ -3,7 +3,8 @@ import itertools
 from tqdm import tqdm
 from fuzzywuzzy import fuzz
 from operator import itemgetter
-from collections.abc import Iterable
+from typing import Any, Callable, Iterable
+from multiprocessing import Pool, cpu_count
 
 from libem.block import parameter
 
@@ -30,42 +31,24 @@ schema = {
 }
 
 
-def func(left, right=None, key=None):
+def func(left, right=None, key=None, ignore=None):
     if right is None:
-        return block(left, key)
+        return block(left, key, ignore)
     else:
-        return block_left_right(left, right, key)
+        return block_left_right(left, right, key, ignore)
 
 
 def block(records: Iterable[str | dict], 
-          key: str | list | None = None) -> Iterable[dict]:
-    if key:
-        if isinstance(key, str):
-            key = [key]
-        elif not isinstance(key, list):
-            raise ValueError("Key must be a string or a list of strings.")
-        
-        # group by
-        records = sorted(records, key=itemgetter(*key))
-        records = itertools.groupby(records, key=itemgetter(*key))
-        
-        for _, group in tqdm(records, desc='Blocking'):
-            # duplicate the iterable to allow for nested iteration
-            left, right = itertools.tee(group, 2)
-            yield from compare(left, right, 
-                               remove_keys=key,
-                               compare_same_index=False)
-    else:
-        # duplicate the iterable to allow for nested iteration
-        left, right = itertools.tee(records, 2)
-        yield from compare(left, right, 
-                           compare_same_index=False, 
-                           progress_bar=True)
-
-
-def block_left_right(left: Iterable[str | dict], 
-                     right: Iterable[str | dict],
-                     key: str | list | None = None) -> Iterable[dict]:
+          key: str | list | None = None,
+          ignore: str | list | None = None) -> Iterable[dict]:
+    
+    if not ignore:
+        ignore = []
+    elif isinstance(ignore, str):
+        ignore = [ignore]
+    elif not isinstance(ignore, list):
+        raise ValueError("Ignore must be a string or a list of strings.")
+    
     if key:
         if isinstance(key, str):
             key = [key]
@@ -73,23 +56,146 @@ def block_left_right(left: Iterable[str | dict],
             raise ValueError("Key must be a string or a list of strings.")
         
         # group by key
-        left = sorted(left, key=itemgetter(*key))
-        left = itertools.groupby(left, key=itemgetter(*key))
-        right = sorted(right, key=itemgetter(*key))
-        right = itertools.groupby(right, key=itemgetter(*key))
+        grouped_records = list(parallel_groupby(records, key=itemgetter(*key)).values())
+        
+        return parallel_block_left_right(grouped_records, grouped_records,
+                                         remove_keys=key + ignore, 
+                                         compare_same_index=False)
+    else:
+        records = list(records)
+        return parallel_block_left_right(records, records, 
+                                         remove_keys=ignore, 
+                                         compare_same_index=False)
+
+
+def block_left_right(left: Iterable[str | dict], 
+                     right: Iterable[str | dict],
+                     key: str | list | None = None,
+                     ignore: str | list | None = None) -> Iterable[dict]:
+    if not ignore:
+        ignore = []
+    elif isinstance(ignore, str):
+        ignore = [ignore]
+    elif not isinstance(ignore, list):
+        raise ValueError("Ignore must be a string or a list of strings.")
+    
+    if key:
+        if isinstance(key, str):
+            key = [key]
+        elif not isinstance(key, list):
+            raise ValueError("Key must be a string or a list of strings.")
+        
+        # group by key
+        left = parallel_groupby(left, key=itemgetter(*key))
+        right = parallel_groupby(right, key=itemgetter(*key))
         
         # inner join the two iterables
-        records = heapq.merge(right, left, key=lambda x: x[0])
-        last_k, last_v = None, []
-        for k, v in tqdm(records, desc='Blocking'):
-            if k == last_k:
-                last_k = None
-                yield from compare(v, last_v, remove_keys=key)
-            else:
-                last_k = k
-                last_v = list(v)
+        common_keys = set(left.keys()) & set(right.keys())
+        left_list = [left[key] for key in common_keys]
+        right_list = [right[key] for key in common_keys]
+        return parallel_block_left_right(
+            left_list, right_list,
+            remove_keys=key + ignore
+        )
     else:
-        yield from compare(left, right, progress_bar=True)
+        left, right = list(left), list(right)
+        return parallel_block_left_right(left, right, 
+                                         remove_keys=ignore)
+
+
+def parallel_groupby(data: Iterable[Any], key: Callable[[Any], Any]) -> dict:
+    ''' Perform a parallelized groupby operation on an iterable. '''
+    
+    # Convert data to a list for slicing
+    data = list(data)
+    chunk_size = max(1, len(data) // cpu_count())
+    chunks = [data[i:i + chunk_size] for i in range(0, len(data), chunk_size)]
+
+    # Process chunks in parallel
+    with Pool(cpu_count()) as pool:
+        args = [(chunk, key) for chunk in chunks]
+        chunk_results = pool.starmap(groupby_chunk, args)
+
+    # Merge results
+    grouped_result = {}
+    for partial_result in chunk_results:
+        for k, v in partial_result.items():
+            if k in grouped_result:
+                grouped_result[k].extend(v)
+            else:
+                grouped_result[k] = v
+
+    return grouped_result
+
+
+def groupby_chunk(chunk: list[Any], key: Callable[[Any], Any]) -> dict:
+    """Group a single chunk."""
+    chunk = sorted(chunk, key=key)  # Groupby requires sorted input
+    return {k: list(g) for k, g in itertools.groupby(chunk, key=key)}
+
+
+def parallel_block_left_right(left: list[str | dict | list],
+                              right: list[str | dict | list],
+                              remove_keys: list | None = None,
+                              compare_same_index: bool = True) -> list[dict]:
+    ''' Run block with multiprocessing. '''
+    
+    with Pool(cpu_count()) as pool:
+        if isinstance(left[0], list): # nested list: pass each sublist to compare
+            if not isinstance(right[0], list):
+                raise ValueError("Left and right must have the same structure.")
+            
+            async_results = [
+                pool.apply_async(
+                    compare, 
+                    args=(l, r, remove_keys, compare_same_index)
+                )
+                for l, r in zip(left, right)
+            ]
+        else: # single list: split into chunks
+            if isinstance(right[0], list):
+                raise ValueError("Left and right must have the same structure.")
+            
+            left_size = len(left)
+            chunk_size = max(1, left_size // cpu_count())
+            left_chunks = [left[i:i + chunk_size] for i in range(0, left_size, chunk_size)]
+            async_results = []
+            
+            if compare_same_index:
+                async_results = [
+                    pool.apply_async(
+                        compare, 
+                        args=(left_chunks[l], right, remove_keys)
+                    )
+                    for l in range(len(left_chunks))
+            ]
+            else:
+                right_size = len(right)
+                if left_size != right_size:
+                    raise ValueError("Left and right must have the same length.")
+                
+                async_results = [
+                    pool.apply_async(
+                        compare, 
+                        args=(left_chunks[l], right[l*chunk_size:], remove_keys, compare_same_index)
+                    )
+                    for l in range(len(left_chunks))
+                ]
+        
+        # Monitor progress and collect results
+        results = []
+        with tqdm(total=len(async_results), desc="Processing") as pbar:
+            for async_result in async_results:
+                try:
+                    results.extend(async_result.get())
+                    pbar.update(1)
+                except Exception as e:
+                    # terminate the pool if an exception occurs
+                    pool.terminate()
+                    pool.join()
+                    raise e
+    
+    return results
 
 
 def compare(left: Iterable[str | dict], 
@@ -102,21 +208,24 @@ def compare(left: Iterable[str | dict],
     # set similarity and convert right iterable to list
     similarity = parameter.similarity()
     right = list(right)
-    
-    if progress_bar:
-        left = tqdm(left, desc='Blocking')
+    result = []
 
     for i, l in enumerate(left):
         left_str = convert_to_str(l, remove_keys)
+        
+        iterable = right
+        if progress_bar:
+            iterable = tqdm(right, desc='Comparing', mininterval=0.01, leave=False)
 
-        for j, r in enumerate(
-                tqdm(right, desc='Comparing', mininterval=0.01, leave=False)):
+        for j, r in enumerate(iterable):
             if not compare_same_index and i >= j:
                 continue
             
             right_str = convert_to_str(r, remove_keys)
             if fuzz.token_set_ratio(left_str, right_str) >= similarity:
-                yield {'left': l, 'right': r}
+                result.append({'left': l, 'right': r})
+    
+    return result
 
 
 def convert_to_str(record: str | dict, remove_keys: Iterable | None = None):
@@ -125,10 +234,8 @@ def convert_to_str(record: str | dict, remove_keys: Iterable | None = None):
             return record
         case dict():
             if remove_keys:
-                record = record.copy()
-                for key in remove_keys:
-                    del record[key]
-            
-            return ' '.join(map(str, record.values()))
+                return ' '.join(map(str, (value for key, value in record.items() if key not in remove_keys)))
+            else:
+                return ' '.join(map(str, record.values()))
         case _:
             return str(record)

--- a/libem/block/interface.py
+++ b/libem/block/interface.py
@@ -18,5 +18,6 @@ Output = Iterable[Pair]
 
 
 def block(left: Left, right: Right = None, 
-          on: str | list | None = None) -> Output:
-    yield from func(left, right, on)
+          key: str | list | None = None, 
+          ignore: str | list | None = None) -> Output:
+    return func(left, right, key, ignore)

--- a/libem/prepare/datasets/linking/amazon_google.py
+++ b/libem/prepare/datasets/linking/amazon_google.py
@@ -1,0 +1,36 @@
+import csv
+import gzip
+import os
+
+from libem.prepare import datasets
+
+def load(num_samples=-1):
+    linking_path = os.path.join(datasets.LIBEM_SAMPLE_DATA_PATH, "linking")
+    path = os.path.join(linking_path, "amazon-google")
+    left, right, mapping = [], [], []
+    
+    with gzip.open(os.path.join(path, "Amazon.csv.gz"), 
+                   'rt', encoding='utf-8', errors='replace') as f:
+        csv_reader = csv.DictReader(f)
+        for i, row in enumerate(csv_reader):
+            if num_samples > 0 and i == num_samples:
+                break
+
+            left.append(row)
+    
+    with gzip.open(os.path.join(path, "GoogleProducts.csv.gz"), 
+                   'rt', encoding='utf-8', errors='replace') as f:
+        csv_reader = csv.DictReader(f)
+        for i, row in enumerate(csv_reader):
+            if num_samples > 0 and i == num_samples:
+                break
+
+            right.append(row)
+            
+    with gzip.open(os.path.join(path, "Amzon_GoogleProducts_perfectMapping.csv.gz"), 
+                   'rt', encoding='utf-8', errors='replace') as f:
+        csv_reader = csv.DictReader(f)
+        for row in csv_reader:
+            mapping.append(row)
+    
+    return left, right, mapping

--- a/test/block.py
+++ b/test/block.py
@@ -1,5 +1,26 @@
 import libem
 
+def assert_equal(list1, list2):
+    ''' Check if two lists of dictionaries with potential nested dictionaries are equal. '''
+
+    def normalize_dict(d):
+        ''' Recursively convert a dictionary into a sorted tuple of key-value pairs. '''
+        return tuple(sorted((k, normalize_value(v)) for k, v in d.items()))
+
+    def normalize_value(v):
+        ''' Normalize a value to handle nested dictionaries or lists. '''
+        if isinstance(v, dict):
+            return normalize_dict(v)
+        elif isinstance(v, list):
+            return tuple(sorted(normalize_value(i) for i in v))
+        return v
+
+    # Normalize the lists of dictionaries
+    normalized_list1 = sorted(normalize_dict(d) for d in list1)
+    normalized_list2 = sorted(normalize_dict(d) for d in list2)
+
+    assert normalized_list1 == normalized_list2
+
 dataset_a = [{'i': 1, 'j': 'apple'}, {'i': 2, 'j': 'apple'}, {'i': 10, 'j': 'apple'}, 
              {'i': 1, 'j': 'apple'}, {'i': 8, 'j': 'apple'}, {'i': 5, 'j': 'orange'}, 
              {'i': 5, 'j': 'orange'}, {'i': 8, 'j': 'orange'}, {'i': 0, 'j': 'orange'}, 
@@ -14,14 +35,16 @@ libem.calibrate({
     "libem.block.parameter.similarity": 0
 })
 
-out = list(libem.block(iter(dataset_a), on='i'))
-assert out == [{'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'apple'}}, 
+out = libem.block(iter(dataset_a), key='i')
+expected  = [{'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'apple'}}, 
                {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
                {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
                {'left': {'i': 8, 'j': 'apple'}, 'right': {'i': 8, 'j': 'orange'}},]
-out = list(libem.block(iter(dataset_a), iter(dataset_b), on='i'))
-assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+assert_equal(out, expected)
+
+out = libem.block(iter(dataset_a), iter(dataset_b), key='i')
+expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
                {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
@@ -29,41 +52,46 @@ assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'
                {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+assert_equal(out, expected)
 
-out = list(libem.block(iter(dataset_a), iter(dataset_b), on=['i', 'j']))
-assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+out = libem.block(iter(dataset_a), iter(dataset_b), key=['i', 'j'])
+expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+assert_equal(out, expected)
 
 libem.calibrate({
     "libem.block.parameter.similarity": 50
 })
 
-out = list(libem.block(dataset_a, dataset_b, on='i'))
-assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+out = libem.block(dataset_a, dataset_b, key='i')
+expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
                {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
                {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+assert_equal(out, expected)
 
 libem.calibrate({
     "libem.block.parameter.similarity": 100
 })
 
-out = list(libem.block(dataset_a, dataset_b, on='i'))
-assert out == [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+out = libem.block(dataset_a, dataset_b, key='i')
+expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},  
                {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+assert_equal(out, expected)
 
-out = list(libem.block(dataset_a, dataset_b))
-assert out == [{'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+out = libem.block(dataset_a, dataset_b)
+expected  = [{'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
                {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
                {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
                {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},]
+assert_equal(out, expected)


### PR DESCRIPTION
#### What this PR does / why we need it:
- add multiprocessing to blocking to speed up for large datasets
- add prepare for the full amazon google dataset

#### Which issue(s) this PR addresses (if any):
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Addresses #<issue number>`, or `Addresses (paste link of issue)`.
-->
Addresses #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- add multiprocessing to blocking to speed up for large datasets
- block no longer returns a generator and will always return the full result as a list
```
