### PR TITLE
feat: support blocking across n datasets

### DIFF
--- a/examples/match.py
+++ b/examples/match.py
@@ -3,7 +3,7 @@ import cv2
 import libem
 
 from libem.match.prompt import rules
-from libem.match.struct import MultimodalEntityDesc
+from libem.struct import MultimodalRecord
 
 
 parent_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -37,10 +37,10 @@ def negative():
 
 
 def multimodal():
-    e1 = MultimodalEntityDesc(text={"name": "fuji apple", "color": "red"},
-                              images=[get_image("apple")])
-    e2 = MultimodalEntityDesc(text={"name": "sweet seedless orange", "color": "orange"},
-                              images=[get_image("orange1"), get_image("orange2")])
+    e1 = MultimodalRecord(text={"name": "fuji apple", "color": "red"},
+                          images=[get_image("apple")])
+    e2 = MultimodalRecord(text={"name": "sweet seedless orange", "color": "orange"},
+                          images=[get_image("orange1"), get_image("orange2")])
 
     is_match = libem.match(e1, e2)
 

--- a/libem/block/interface.py
+++ b/libem/block/interface.py
@@ -1,23 +1,20 @@
-from typing import TypedDict
 from collections.abc import Iterable
 
 from libem.block.function import func
-
-EntityDesc = str | dict
-
-Left = Iterable[EntityDesc]
-Right = Iterable[EntityDesc] | None
-
-
-class Pair(TypedDict):
-    left: EntityDesc | list[EntityDesc]
-    right: EntityDesc | list[EntityDesc]
+from libem.struct import Record, Pair
 
 
 Output = Iterable[Pair]
 
 
-def block(left: Left, right: Right = None, 
+def block(*records: Record, 
           key: str | list | None = None, 
           ignore: str | list | None = None) -> Output:
-    return func(left, right, key, ignore)
+    '''
+    Perform the blocking stage of entity matching given one or more datasets.
+    If multiple datasets are passed in, only block across the datasets.
+    
+    Output format: [{"left": record, "right": record}, ...]
+    '''
+    
+    return func(*records, key=key, ignore=ignore)

--- a/libem/block/parameter.py
+++ b/libem/block/parameter.py
@@ -4,3 +4,8 @@ similarity = Parameter(
     default=60,
     options=[]
 )
+
+batch_size = Parameter(
+    default=10000,
+    options=[]
+)

--- a/libem/block/struct.py
+++ b/libem/block/struct.py
@@ -1,0 +1,33 @@
+from libem.struct import *
+
+
+# internal types
+class _TextRecord(BaseModel):
+    text: str | Mapping
+
+class _ImageRecord(BaseModel):
+    image: ImageField
+    class Config:
+        arbitrary_types_allowed = True
+
+_Record = _TextRecord | _ImageRecord | MultimodalRecord
+
+
+def parse_input(record: Record) -> list[_Record]:
+    match record:
+        case str() | Mapping():
+            return [_TextRecord(text=record)]
+        case Image.Image() | np.ndarray():
+            return [_ImageRecord(image=record)]
+        case MultimodalRecord():
+            return [record]
+        case Iterable():
+            output = []
+            for r in record:
+                output.extend(parse_input(r))
+            return output
+        case _:
+            raise ValueError(
+                f"unexpected input type: {type(record)},"
+                f"must be {Record}."
+            )

--- a/libem/match/interface.py
+++ b/libem/match/interface.py
@@ -2,12 +2,10 @@ import random
 
 from libem.match import (
     parameter,
-    func, async_func,
+    func, async_func
 )
-from libem.match.struct import (
-    Left, Right, Output,
-    parse_input,
-)
+from libem.struct import Left, Right, Output
+from libem.match.struct import parse_input
 
 
 def match(left: Left, right: Right = None) -> Output:

--- a/libem/resolve/cluster/integrations/pandas.py
+++ b/libem/resolve/cluster/integrations/pandas.py
@@ -27,13 +27,18 @@ def cluster(*args, **kwargs):
     return func(*args, **kwargs)
 
 
-def func(df: pd.DataFrame, sort: bool = False) -> pd.DataFrame:
+def func(*dfs: pd.DataFrame, sort: bool = False) -> pd.DataFrame:
     clusters = cluster_func(
-        df.to_dict(orient="records")
+        *[df.to_dict(orient="records") for df in dfs]
     )
-
-    new_df = df.copy()
-    new_df["__cluster__"] = [cluster_id for cluster_id, _ in clusters]
+    print(clusters)
+    
+    rows = []
+    for cluster_id, record in clusters:
+        row = record.copy()
+        row["__cluster__"] = cluster_id
+        rows.append(row)
+    new_df = pd.DataFrame(rows)
 
     if sort:
         return new_df.sort_values(by="__cluster__")

--- a/libem/resolve/cluster/interface.py
+++ b/libem/resolve/cluster/interface.py
@@ -3,6 +3,7 @@ from typing import (
     TYPE_CHECKING
 )
 
+from libem.struct import SingleRecord
 from libem.resolve.cluster.function import func
 
 if TYPE_CHECKING:
@@ -11,8 +12,7 @@ if TYPE_CHECKING:
     from libem.resolve.cluster.integrations import mongodb
 
 InputType = Union[
-    Iterator[str],
-    Iterator[dict],
+    Iterator[SingleRecord],
     "pd.DataFrame",
     "duckdb.Table",
     "mongodb.Collection",
@@ -21,33 +21,40 @@ InputType = Union[
 ID = int
 
 OutputType = Union[
-    list[(ID, str)],
-    list[(ID, dict)],
+    list[(ID, SingleRecord)],
     "pd.DataFrame",
     "duckdb.Table",
     "mongodb.Collection",
 ]
 
 
-def cluster(records: InputType, *, sort=False) -> OutputType:
+def cluster(*records: InputType, sort=False) -> OutputType:
     import pandas as pd
 
     from libem.resolve.cluster.integrations import pandas
     from libem.resolve.cluster.integrations import duckdb
     from libem.resolve.cluster.integrations import mongodb
-
-    match records:
-        case pd.DataFrame():
-            return pandas.cluster(records, sort)
-        case duckdb.Table():
-            return duckdb.cluster(records, sort)
-        case mongodb.Collection():
-            return mongodb.cluster(records, sort)
+    
+    first_type = type(records[0])
+    for record in records:
+        assert type(record) == first_type
+    
+    match first_type:
+        case pd.DataFrame:
+            return pandas.cluster(*records, sort=sort)
+        case duckdb.Table:
+            if len(records) > 1:
+                raise NotImplementedError
+            return duckdb.cluster(records[0], sort=sort)
+        case mongodb.Collection:
+            if len(records) > 1:
+                raise NotImplementedError
+            return mongodb.cluster(records[0], sort=sort)
         case _:
             if sort:
-                return sorted(func(records), key=lambda x: x[0])
+                return sorted(func(*records), key=lambda x: x[0])
             else:
-                return func(records)
+                return func(*records)
 
 
 def eval(truths: list[int], preds: list[int]) -> dict:

--- a/libem/struct.py
+++ b/libem/struct.py
@@ -1,0 +1,71 @@
+from collections.abc import Iterable, Mapping
+from typing import TypedDict
+from pydantic import BaseModel
+from PIL import Image
+import numpy as np
+
+# Input types
+TextField = str
+TextFields = TextField | Mapping[str, TextField]
+ImageField = Image.Image | np.ndarray | str
+ImageFields = ImageField | Mapping[str, ImageField] | Iterable[ImageField]
+
+
+class MultimodalRecord(BaseModel):
+    text: TextFields | None = None
+    images: ImageFields | None = None
+    
+    class Config:
+        arbitrary_types_allowed = True
+
+# If multiple images belong to the same record 
+# (in an Iterable or Mapping), use MultimodalRecord
+SingleRecord = TextFields | ImageField | MultimodalRecord
+Record = SingleRecord | Iterable[SingleRecord]
+
+
+class Pair(TypedDict):
+    left: Record
+    right: Record
+
+
+Left = Record | Pair | Iterable[Pair]
+Right = Record | None
+
+
+# Output types
+class Answer(TypedDict):
+    answer: str | float
+    confidence: float | None
+    explanation: str | None
+
+
+Output = Answer | list[Answer]
+
+
+def digest(record: SingleRecord) -> str:
+    ''' Generate an MD5 hash for a single record. '''
+    import hashlib
+    import io
+    import json
+
+    match record:
+        case str():
+            data = record.encode()
+        case Mapping():
+            data = json.dumps(record, sort_keys=True).encode()
+        case np.ndarray():
+            data = record.tobytes() + str(record.shape).encode()
+        case Image.Image():
+            buf = io.BytesIO()
+            record.save(buf, format='PNG')
+            data = buf.getvalue()
+        case MultimodalRecord():
+            text = json.dumps(record.text, sort_keys=True).encode()
+            images = b''.join([
+                digest(image) for image in record.images
+            ])
+            data = text + images
+        case _:
+            data = str(record).encode()
+    return hashlib.md5(data).hexdigest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ requests
 jsonref
 opencv-python
 Pillow
+ray>=2.43.0
+pyarrow

--- a/test/block.py
+++ b/test/block.py
@@ -19,7 +19,7 @@ def assert_equal(list1, list2):
     normalized_list1 = sorted(normalize_dict(d) for d in list1)
     normalized_list2 = sorted(normalize_dict(d) for d in list2)
 
-    assert normalized_list1 == normalized_list2
+    assert normalized_list1 == normalized_list2, list1
 
 dataset_a = [{'i': 1, 'j': 'apple'}, {'i': 2, 'j': 'apple'}, {'i': 10, 'j': 'apple'}, 
              {'i': 1, 'j': 'apple'}, {'i': 8, 'j': 'apple'}, {'i': 5, 'j': 'orange'}, 
@@ -37,43 +37,43 @@ libem.calibrate({
 
 out = libem.block(iter(dataset_a), key='i')
 expected  = [{'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'apple'}}, 
-               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
-               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
-               {'left': {'i': 8, 'j': 'apple'}, 'right': {'i': 8, 'j': 'orange'}},]
+             {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
+             {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'orange'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+             {'left': {'i': 8, 'j': 'apple'}, 'right': {'i': 8, 'j': 'orange'}},]
 assert_equal(out, expected)
 
 out = libem.block(iter(dataset_a), iter(dataset_b), key='i')
 expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
-               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
-               {'left': {'i': 1, 'j': 'orange'}, 'right': {'i': 1, 'j': 'aple'}}, 
-               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+             {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+             {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+             {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+             {'left': {'i': 1, 'j': 'orange'}, 'right': {'i': 1, 'j': 'aple'}}, 
+             {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
 assert_equal(out, expected)
 
 out = libem.block(iter(dataset_a), iter(dataset_b), key=['i', 'j'])
 expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+             {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+             {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
 assert_equal(out, expected)
 
 libem.calibrate({
-    "libem.block.parameter.similarity": 50
+    "libem.block.parameter.similarity": 60
 })
 
 out = libem.block(dataset_a, dataset_b, key='i')
 expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
-               {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
-               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+             {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+             {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+             {'left': {'i': 1, 'j': 'apple'}, 'right': {'i': 1, 'j': 'aple'}}, 
+             {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
 assert_equal(out, expected)
 
 libem.calibrate({
@@ -82,16 +82,85 @@ libem.calibrate({
 
 out = libem.block(dataset_a, dataset_b, key='i')
 expected  = [{'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},  
-               {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
+             {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},  
+             {'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}},]
 assert_equal(out, expected)
 
 out = libem.block(dataset_a, dataset_b)
 expected  = [{'left': {'i': 2, 'j': 'apple'}, 'right': {'i': 2, 'j': 'apple'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
-               {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
-               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
-               {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},]
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+             {'left': {'i': 5, 'j': 'orange'}, 'right': {'i': 5, 'j': 'orange'}}, 
+             {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}}, 
+             {'left': {'i': 0, 'j': 'orange'}, 'right': {'i': 0, 'j': 'orange'}},]
 assert_equal(out, expected)
+
+text_only_a = ['apple', 'appl', 'orange', 'apple']
+text_only_b = ['orange', 'lemon']
+text_only_c = ['aple', 'orang']
+
+out = libem.block(text_only_a)
+expected = [{'left': 'apple', 'right': 'apple'}]
+assert_equal(out, expected)
+
+out = libem.block(text_only_a, text_only_b, text_only_c)
+expected = [{'left': 'orange', 'right': 'orange'}]
+assert_equal(out, expected)
+
+libem.calibrate({
+    "libem.block.parameter.similarity": 60
+})
+
+out = libem.block(text_only_a)
+expected = [{'left': 'apple', 'right': 'appl'},
+            {'left': 'apple', 'right': 'apple'},
+            {'left': 'appl', 'right': 'apple'}]
+assert_equal(out, expected)
+
+out = libem.block(text_only_a, text_only_b, text_only_c)
+expected = [{'left': 'orange', 'right': 'orange'},
+            {'left': 'apple', 'right': 'aple'},
+            {'left': 'appl', 'right': 'aple'},
+            {'left': 'orange', 'right': 'orang'},
+            {'left': 'apple', 'right': 'aple'},
+            {'left': 'orange', 'right': 'orang'}]
+assert_equal(out, expected)
+
+
+import os
+import cv2
+import numpy as np
+from libem.struct import MultimodalRecord
+
+current_directory = os.path.dirname(os.path.abspath(__file__))
+
+def get_image(name):
+    return cv2.imread(os.path.join(current_directory, f"images/{name}.jpg"))
+
+multimodal = [
+        MultimodalRecord(text={"name": "apple", "color": "red"}, 
+                             images=get_image("apple")),
+        MultimodalRecord(text={"name": "lemon", "color": "yellow"}, 
+                             images=[get_image("lemon")]),
+        MultimodalRecord(text={"name": "fuji apple"})
+    ]
+
+libem.calibrate({
+    "libem.block.parameter.similarity": 40
+})
+
+out = libem.block(multimodal)
+text_fields = [{'left': o['left'].text, 'right': o['right'].text} for o in out]
+expected = [{'left': {'name': 'apple', 'color': 'red'},
+             'right': {'name': 'fuji apple'}}]
+assert_equal(text_fields, expected)
+assert np.array_equal(out[0]['left'].images, get_image("apple"))
+assert out[0]['right'].images is None
+
+multimodal.append(get_image("orange1"))
+
+out = libem.block(multimodal)
+assert len(out) == 4
+
+print("All tests passed.")

--- a/test/match.py
+++ b/test/match.py
@@ -2,7 +2,7 @@ import os
 import cv2
 from PIL import Image
 import libem
-from libem.match.struct import MultimodalEntityDesc
+from libem.struct import MultimodalRecord
 
 current_directory = os.path.dirname(os.path.abspath(__file__))
 
@@ -21,13 +21,13 @@ def main():
     assert output == "yes", output
     
     fruits = [
-        MultimodalEntityDesc(text={"name": "apple", "color": "red"}, 
-                             images=get_image("apple")),
-        MultimodalEntityDesc(text={"name": "sweet seedless orange", "color": "orange"}, 
-                             images=[get_image("orange1"), get_image("orange2")]),
-        MultimodalEntityDesc(text={"name": "lemon", "color": "yellow"}, 
-                             images=[get_image("lemon")]),
-        MultimodalEntityDesc(text={"name": "fuji apple"})
+        MultimodalRecord(text={"name": "apple", "color": "red"}, 
+                         images=get_image("apple")),
+        MultimodalRecord(text={"name": "sweet seedless orange", "color": "orange"}, 
+                         images=[get_image("orange1"), get_image("orange2")]),
+        MultimodalRecord(text={"name": "lemon", "color": "yellow"}, 
+                         images=[get_image("lemon")]),
+        MultimodalRecord(text={"name": "fuji apple"})
     ]
     
     # dict only
@@ -67,10 +67,10 @@ def main():
     
     # image only
     fruits = [
-        MultimodalEntityDesc(images=get_pil_image("apple")),
-        MultimodalEntityDesc(images=[get_image("orange1"), get_pil_image("orange2")]),
-        MultimodalEntityDesc(text={"name": "red apple"}),
-        MultimodalEntityDesc(images=["https://media.istockphoto.com/id/184276818/photo/red-apple.jpg?s=612x612&w=0&k=20&c=NvO-bLsG0DJ_7Ii8SSVoKLurzjmV0Qi4eGfn6nW3l5w="])
+        MultimodalRecord(images=get_pil_image("apple")),
+        MultimodalRecord(images=[get_image("orange1"), get_pil_image("orange2")]),
+        MultimodalRecord(text={"name": "red apple"}),
+        MultimodalRecord(images=["https://media.istockphoto.com/id/184276818/photo/red-apple.jpg?s=612x612&w=0&k=20&c=NvO-bLsG0DJ_7Ii8SSVoKLurzjmV0Qi4eGfn6nW3l5w="])
     ]
     output = [o['answer'] for o in libem.match([fruits[0]] * 3, fruits[1:])]
     assert output == ["no", "yes", "yes"], output


### PR DESCRIPTION
#### What this PR does / why we need it:
- redesign block module
  - support operation across n datasets
  - use Ray instead of multiprocessing for parallel computation
  - add support for multimodal input (same as match module)
- standardize input types/structs
  - make input typing hints/structs from the match module reusable (now in `libem.struct`)
  - rename EntityDesc -> Record
  - create digest function to support all valid input types
- add n-way input support for dedupe and link
  - currently only supports pandas and dict types

#### Which issue(s) this PR addresses (if any):
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Addresses #<issue number>`, or `Addresses (paste link of issue)`.
-->
Addresses #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- remove `left` and `right` parameters from `libem.block()`, now support passing in any number of datasets
```
